### PR TITLE
dependabotの設定ファイルを追加

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  - package-ecosystem: docker-compose
+    directory: /
+    schedule:
+      interval: monthly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Closes #16
最近Docker Composeもサポートされたので、dependabotで十分かなという感じがした