### PR TITLE
`GetOrCreateUser`内でのtraQ APIの呼び出しを削除

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/gavv/httpexpect/v2 v2.17.0
 	github.com/go-gormigrate/gormigrate/v2 v2.1.4
 	github.com/go-sql-driver/mysql v1.9.3
-	github.com/google/uuid v1.6.0
 	github.com/jinzhu/copier v0.4.0
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo/v4 v4.13.4
@@ -56,6 +55,7 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/imkira/go-interpol v1.1.0 // indirect
 	github.com/invopop/yaml v0.3.1 // indirect

--- a/model/user.go
+++ b/model/user.go
@@ -3,7 +3,6 @@ package model
 import (
 	"time"
 
-	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
@@ -13,7 +12,6 @@ type User struct {
 	UpdatedAt time.Time
 	DeletedAt gorm.DeletedAt `gorm:"index"`
 	IsStaff   bool           `gorm:"index"`
-	TraqUUID  uuid.UUID
 
 	Answers         []Answer
 	Payments        []Payment

--- a/repository/gorm/repository_test.go
+++ b/repository/gorm/repository_test.go
@@ -97,3 +97,17 @@ func mustCreateCamp(t *testing.T, r *Repository) model.Camp {
 
 	return *camp
 }
+
+func mustCreateUser(t *testing.T, r *Repository) model.User {
+	t.Helper()
+
+	userID := random.AlphaNumericString(t, 32)
+	user, err := r.GetOrCreateUser(t.Context(), userID)
+
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	require.Equal(t, userID, user.ID)
+	require.False(t, user.IsStaff)
+
+	return *user
+}

--- a/repository/gorm/user_test.go
+++ b/repository/gorm/user_test.go
@@ -1,0 +1,39 @@
+package gorm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/traPtitech/rucQ/testutil/random"
+)
+
+func TestGetOrCreateUser(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success (New User)", func(t *testing.T) {
+		t.Parallel()
+
+		r := setup(t)
+		userID := random.AlphaNumericString(t, 32)
+		user, err := r.GetOrCreateUser(t.Context(), userID)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, user)
+		assert.Equal(t, userID, user.ID)
+		assert.False(t, user.IsStaff)
+	})
+
+	t.Run("Success (Existing User)", func(t *testing.T) {
+		t.Parallel()
+
+		r := setup(t)
+		user := mustCreateUser(t, r)
+		got, err := r.GetOrCreateUser(t.Context(), user.ID)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, got)
+		assert.Equal(t, user.ID, got.ID)
+		assert.False(t, got.IsStaff)
+	})
+}


### PR DESCRIPTION
Closes #43
UUID取得のためのAPI呼び出しを削除した
このUUIDはtraQでDMを送信するのにのみ使われていたが、DMの送信機能には改善が必要（予約投稿のキューが永続化されていないので再起動で消える）なのでここではDM関連のところは放置する