### PR TITLE
`GetDashboard`関数を実装

### DIFF
--- a/router/dashboard.go
+++ b/router/dashboard.go
@@ -1,0 +1,18 @@
+package router
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/traPtitech/rucQ/api"
+)
+
+func (s *Server) GetDashboard(e echo.Context, _ api.CampId, params api.GetDashboardParams) error {
+	// TODO: ユーザーのPaymentとRoomを取得してレスポンスに含める
+	res := api.DashboardResponse{
+		Id: *params.XForwardedUser,
+	}
+
+	return e.JSON(http.StatusOK, &res)
+}

--- a/router/dashboard_test.go
+++ b/router/dashboard_test.go
@@ -1,0 +1,26 @@
+package router
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/traPtitech/rucQ/testutil/random"
+)
+
+func TestGetDashboard(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+
+		h := setup(t)
+		campID := random.PositiveInt(t)
+		userID := random.AlphaNumericString(t, 32)
+		res := h.expect.GET(fmt.Sprintf("/api/camps/%d/me", campID)).WithHeader("X-Forwarded-User", userID).
+			Expect().Status(http.StatusOK).JSON().Object()
+
+		res.Keys().ContainsOnly("id")
+		res.Value("id").String().IsEqual(userID)
+	})
+}

--- a/router/stubs.go
+++ b/router/stubs.go
@@ -95,11 +95,6 @@ func (s *Server) GetImage(_ echo.Context, _ api.ImageId) error {
 	return echo.NewHTTPError(http.StatusNotImplemented, "GetImage not implemented")
 }
 
-// GetDashboard 自分の参加する合宿を取得
-func (s *Server) GetDashboard(_ echo.Context, _ api.CampId, _ api.GetDashboardParams) error {
-	return echo.NewHTTPError(http.StatusNotImplemented, "GetDashboard not implemented")
-}
-
 // GetRollCalls 点呼の一覧を取得
 func (s *Server) GetRollCalls(_ echo.Context, _ api.CampId) error {
 	return echo.NewHTTPError(http.StatusNotImplemented, "GetRollCalls not implemented")


### PR DESCRIPTION
Closes #57
ユーザーの合宿参加情報を返すエンドポイントの実装
Payment、Room関連の実装がまだなのであまり意味はないが、とりあえずNot implementedエラーを返すのはやめる