### PR TITLE
SingleChoiceAnswerを更新すると選択肢が複数選ばれてしまっていたのを修正

### DIFF
--- a/repository/answer.go
+++ b/repository/answer.go
@@ -15,5 +15,5 @@ type AnswerRepository interface {
 		userID string,
 		questionGroupID uint,
 	) ([]model.Answer, error)
-	UpdateAnswer(answer *model.Answer) error
+	UpdateAnswer(ctx context.Context, answer *model.Answer) error
 }

--- a/repository/answer.go
+++ b/repository/answer.go
@@ -15,5 +15,5 @@ type AnswerRepository interface {
 		userID string,
 		questionGroupID uint,
 	) ([]model.Answer, error)
-	UpdateAnswer(ctx context.Context, answer *model.Answer) error
+	UpdateAnswer(ctx context.Context, answerID uint, answer *model.Answer) error
 }

--- a/repository/answer.go
+++ b/repository/answer.go
@@ -9,7 +9,7 @@ import (
 
 type AnswerRepository interface {
 	CreateAnswers(ctx context.Context, answers *[]model.Answer) error
-	GetAnswerByID(id uint) (*model.Answer, error)
+	GetAnswerByID(ctx context.Context, id uint) (*model.Answer, error)
 	GetAnswersByUserAndQuestionGroup(
 		ctx context.Context,
 		userID string,

--- a/repository/gorm/answer.go
+++ b/repository/gorm/answer.go
@@ -55,7 +55,7 @@ func (r *Repository) UpdateAnswer(ctx context.Context, answerID uint, answer *mo
 		return err
 	}
 
-	if err := r.db.Model(answer).Association("SelectedOptions").Replace(answer.SelectedOptions); err != nil {
+	if err := r.db.WithContext(ctx).Model(answer).Association("SelectedOptions").Replace(answer.SelectedOptions); err != nil {
 		return err
 	}
 

--- a/repository/gorm/answer.go
+++ b/repository/gorm/answer.go
@@ -47,8 +47,8 @@ func (r *Repository) GetAnswersByUserAndQuestionGroup(
 	return answers, nil
 }
 
-func (r *Repository) UpdateAnswer(ctx context.Context, answer *model.Answer) error {
-	if err := r.db.Save(answer).Error; err != nil {
+func (r *Repository) UpdateAnswer(ctx context.Context, answerID uint, answer *model.Answer) error {
+	if _, err := gorm.G[*model.Answer](r.db).Where("id = ?", answerID).Updates(ctx, answer); err != nil {
 		return err
 	}
 

--- a/repository/gorm/answer.go
+++ b/repository/gorm/answer.go
@@ -47,7 +47,7 @@ func (r *Repository) GetAnswersByUserAndQuestionGroup(
 	return answers, nil
 }
 
-func (r *Repository) UpdateAnswer(answer *model.Answer) error {
+func (r *Repository) UpdateAnswer(ctx context.Context, answer *model.Answer) error {
 	if err := r.db.Save(answer).Error; err != nil {
 		return err
 	}

--- a/repository/gorm/answer_test.go
+++ b/repository/gorm/answer_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/traPtitech/rucQ/model"
 	"github.com/traPtitech/rucQ/testutil/random"
@@ -178,5 +179,53 @@ func TestGetAnswersByUserAndQuestionGroup(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Empty(t, result) // 別のユーザーの回答は取得されない
+	})
+}
+
+func TestUpdateAnswer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success with SingleChoiceQuestion", func(t *testing.T) {
+		t.Parallel()
+
+		r := setup(t)
+		camp := mustCreateCamp(t, r)
+		user := mustCreateUser(t, r)
+		questionGroup := mustCreateQuestionGroup(t, r, camp.ID)
+		singleChoiceQuestion := mustCreateQuestion(
+			t,
+			r,
+			questionGroup.ID,
+			model.SingleChoiceQuestion,
+		)
+
+		answers := []model.Answer{
+			{
+				QuestionID: singleChoiceQuestion.ID,
+				UserID:     user.ID,
+				Type:       model.SingleChoiceQuestion,
+				SelectedOptions: []model.Option{
+					singleChoiceQuestion.Options[0],
+				},
+			},
+		}
+
+		err := r.CreateAnswers(t.Context(), &answers)
+		require.NoError(t, err)
+
+		// CreateAnswers後に作成されたanswerのIDを取得
+		createdAnswer := answers[0]
+		require.NotZero(t, createdAnswer.ID)
+
+		// 選択肢を変更してアップデート
+		createdAnswer.SelectedOptions = []model.Option{singleChoiceQuestion.Options[1]}
+
+		err = r.UpdateAnswer(t.Context(), createdAnswer.ID, &createdAnswer)
+		assert.NoError(t, err)
+
+		retrievedAnswer, err := r.GetAnswerByID(t.Context(), createdAnswer.ID)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(retrievedAnswer.SelectedOptions))
+		assert.Equal(t, createdAnswer.SelectedOptions[0].ID, retrievedAnswer.SelectedOptions[0].ID)
 	})
 }

--- a/repository/gorm/repository_test.go
+++ b/repository/gorm/repository_test.go
@@ -211,7 +211,8 @@ func mustCreateQuestion(
 
 	switch questionType {
 	case model.SingleChoiceQuestion, model.MultipleChoiceQuestion:
-		question.Options = make([]model.Option, random.PositiveIntN(t, 10))
+		// 2つ以上の選択肢を作成する
+		question.Options = make([]model.Option, random.PositiveIntN(t, 10)+1)
 
 		for i := range question.Options {
 			question.Options[i] = model.Option{

--- a/repository/mock/answer.go
+++ b/repository/mock/answer.go
@@ -86,15 +86,15 @@ func (mr *MockAnswerRepositoryMockRecorder) GetAnswersByUserAndQuestionGroup(ctx
 }
 
 // UpdateAnswer mocks base method.
-func (m *MockAnswerRepository) UpdateAnswer(answer *model.Answer) error {
+func (m *MockAnswerRepository) UpdateAnswer(ctx context.Context, answer *model.Answer) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateAnswer", answer)
+	ret := m.ctrl.Call(m, "UpdateAnswer", ctx, answer)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateAnswer indicates an expected call of UpdateAnswer.
-func (mr *MockAnswerRepositoryMockRecorder) UpdateAnswer(answer any) *gomock.Call {
+func (mr *MockAnswerRepositoryMockRecorder) UpdateAnswer(ctx, answer any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAnswer", reflect.TypeOf((*MockAnswerRepository)(nil).UpdateAnswer), answer)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAnswer", reflect.TypeOf((*MockAnswerRepository)(nil).UpdateAnswer), ctx, answer)
 }

--- a/repository/mock/answer.go
+++ b/repository/mock/answer.go
@@ -86,15 +86,15 @@ func (mr *MockAnswerRepositoryMockRecorder) GetAnswersByUserAndQuestionGroup(ctx
 }
 
 // UpdateAnswer mocks base method.
-func (m *MockAnswerRepository) UpdateAnswer(ctx context.Context, answer *model.Answer) error {
+func (m *MockAnswerRepository) UpdateAnswer(ctx context.Context, answerID uint, answer *model.Answer) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateAnswer", ctx, answer)
+	ret := m.ctrl.Call(m, "UpdateAnswer", ctx, answerID, answer)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateAnswer indicates an expected call of UpdateAnswer.
-func (mr *MockAnswerRepositoryMockRecorder) UpdateAnswer(ctx, answer any) *gomock.Call {
+func (mr *MockAnswerRepositoryMockRecorder) UpdateAnswer(ctx, answerID, answer any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAnswer", reflect.TypeOf((*MockAnswerRepository)(nil).UpdateAnswer), ctx, answer)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAnswer", reflect.TypeOf((*MockAnswerRepository)(nil).UpdateAnswer), ctx, answerID, answer)
 }

--- a/repository/mock/answer.go
+++ b/repository/mock/answer.go
@@ -56,18 +56,18 @@ func (mr *MockAnswerRepositoryMockRecorder) CreateAnswers(ctx, answers any) *gom
 }
 
 // GetAnswerByID mocks base method.
-func (m *MockAnswerRepository) GetAnswerByID(id uint) (*model.Answer, error) {
+func (m *MockAnswerRepository) GetAnswerByID(ctx context.Context, id uint) (*model.Answer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAnswerByID", id)
+	ret := m.ctrl.Call(m, "GetAnswerByID", ctx, id)
 	ret0, _ := ret[0].(*model.Answer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAnswerByID indicates an expected call of GetAnswerByID.
-func (mr *MockAnswerRepositoryMockRecorder) GetAnswerByID(id any) *gomock.Call {
+func (mr *MockAnswerRepositoryMockRecorder) GetAnswerByID(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAnswerByID", reflect.TypeOf((*MockAnswerRepository)(nil).GetAnswerByID), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAnswerByID", reflect.TypeOf((*MockAnswerRepository)(nil).GetAnswerByID), ctx, id)
 }
 
 // GetAnswersByUserAndQuestionGroup mocks base method.

--- a/router/answers.go
+++ b/router/answers.go
@@ -105,7 +105,7 @@ func (s *Server) PutAnswer(
 	answer.ID = uint(answerID)
 	answer.UserID = *params.XForwardedUser
 
-	if err := s.repo.UpdateAnswer(&answer); err != nil {
+	if err := s.repo.UpdateAnswer(e.Request().Context(), &answer); err != nil {
 		e.Logger().Errorf("failed to update answer: %v", err)
 
 		return echo.NewHTTPError(http.StatusInternalServerError, "Internal server error")

--- a/router/answers.go
+++ b/router/answers.go
@@ -102,6 +102,7 @@ func (s *Server) PutAnswer(
 		return echo.NewHTTPError(http.StatusInternalServerError, "Internal server error")
 	}
 
+	answer.ID = uint(answerID)
 	answer.UserID = *params.XForwardedUser
 
 	if err := s.repo.UpdateAnswer(e.Request().Context(), uint(answerID), &answer); err != nil {

--- a/router/answers.go
+++ b/router/answers.go
@@ -102,10 +102,9 @@ func (s *Server) PutAnswer(
 		return echo.NewHTTPError(http.StatusInternalServerError, "Internal server error")
 	}
 
-	answer.ID = uint(answerID)
 	answer.UserID = *params.XForwardedUser
 
-	if err := s.repo.UpdateAnswer(e.Request().Context(), &answer); err != nil {
+	if err := s.repo.UpdateAnswer(e.Request().Context(), uint(answerID), &answer); err != nil {
 		e.Logger().Errorf("failed to update answer: %v", err)
 
 		return echo.NewHTTPError(http.StatusInternalServerError, "Internal server error")

--- a/router/answers_test.go
+++ b/router/answers_test.go
@@ -191,7 +191,7 @@ func TestPutAnswer(t *testing.T) {
 
 		h := setup(t)
 		userID := random.AlphaNumericString(t, 32)
-		answerID := random.PositiveInt(t)
+		answerID := uint(random.PositiveInt(t))
 
 		freeTextAnswer := api.FreeTextAnswerRequest{
 			Type:       api.FreeTextAnswerRequestTypeFreeText,
@@ -203,7 +203,7 @@ func TestPutAnswer(t *testing.T) {
 		require.NoError(t, err)
 
 		h.repo.MockAnswerRepository.EXPECT().
-			UpdateAnswer(gomock.Any(), gomock.Any()).
+			UpdateAnswer(gomock.Any(), answerID, gomock.Any()).
 			Return(nil).
 			Times(1)
 
@@ -226,7 +226,7 @@ func TestPutAnswer(t *testing.T) {
 
 		h := setup(t)
 		userID := random.AlphaNumericString(t, 32)
-		answerID := random.PositiveInt(t)
+		answerID := uint(random.PositiveInt(t))
 
 		freeNumberAnswer := api.FreeNumberAnswerRequest{
 			Type:       api.FreeNumberAnswerRequestTypeFreeNumber,
@@ -238,7 +238,7 @@ func TestPutAnswer(t *testing.T) {
 		require.NoError(t, err)
 
 		h.repo.MockAnswerRepository.EXPECT().
-			UpdateAnswer(gomock.Any(), gomock.Any()).
+			UpdateAnswer(gomock.Any(), answerID, gomock.Any()).
 			Return(nil).
 			Times(1)
 
@@ -263,7 +263,7 @@ func TestPutAnswer(t *testing.T) {
 
 		h := setup(t)
 		userID := random.AlphaNumericString(t, 32)
-		answerID := random.PositiveInt(t)
+		answerID := uint(random.PositiveInt(t))
 
 		singleChoiceAnswer := api.SingleChoiceAnswerRequest{
 			Type:       api.SingleChoiceAnswerRequestTypeSingle,
@@ -275,7 +275,7 @@ func TestPutAnswer(t *testing.T) {
 		require.NoError(t, err)
 
 		h.repo.MockAnswerRepository.EXPECT().
-			UpdateAnswer(gomock.Any(), gomock.Any()).
+			UpdateAnswer(gomock.Any(), answerID, gomock.Any()).
 			Return(nil).
 			Times(1)
 
@@ -301,7 +301,7 @@ func TestPutAnswer(t *testing.T) {
 
 		h := setup(t)
 		userID := random.AlphaNumericString(t, 32)
-		answerID := random.PositiveInt(t)
+		answerID := uint(random.PositiveInt(t))
 
 		multipleChoiceAnswer := api.MultipleChoiceAnswerRequest{
 			Type:       api.MultipleChoiceAnswerRequestTypeMultiple,
@@ -313,7 +313,7 @@ func TestPutAnswer(t *testing.T) {
 		require.NoError(t, err)
 
 		h.repo.MockAnswerRepository.EXPECT().
-			UpdateAnswer(gomock.Any(), gomock.Any()).
+			UpdateAnswer(gomock.Any(), answerID, gomock.Any()).
 			Return(nil).
 			Times(1)
 

--- a/router/answers_test.go
+++ b/router/answers_test.go
@@ -203,7 +203,7 @@ func TestPutAnswer(t *testing.T) {
 		require.NoError(t, err)
 
 		h.repo.MockAnswerRepository.EXPECT().
-			UpdateAnswer(gomock.Any()).
+			UpdateAnswer(gomock.Any(), gomock.Any()).
 			Return(nil).
 			Times(1)
 
@@ -238,7 +238,7 @@ func TestPutAnswer(t *testing.T) {
 		require.NoError(t, err)
 
 		h.repo.MockAnswerRepository.EXPECT().
-			UpdateAnswer(gomock.Any()).
+			UpdateAnswer(gomock.Any(), gomock.Any()).
 			Return(nil).
 			Times(1)
 
@@ -275,7 +275,7 @@ func TestPutAnswer(t *testing.T) {
 		require.NoError(t, err)
 
 		h.repo.MockAnswerRepository.EXPECT().
-			UpdateAnswer(gomock.Any()).
+			UpdateAnswer(gomock.Any(), gomock.Any()).
 			Return(nil).
 			Times(1)
 
@@ -313,7 +313,7 @@ func TestPutAnswer(t *testing.T) {
 		require.NoError(t, err)
 
 		h.repo.MockAnswerRepository.EXPECT().
-			UpdateAnswer(gomock.Any()).
+			UpdateAnswer(gomock.Any(), gomock.Any()).
 			Return(nil).
 			Times(1)
 


### PR DESCRIPTION
これにより、選択肢が1つであることを前提とした型変換に失敗してクライアントに`null`として返っていた