### PR TITLE
docker/build-push-actionのタグ設定を修正し、metadata-actionの使用を削除

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,21 +46,13 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v5
-        id: meta
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-
       - uses: docker/build-push-action@v6
         id: build
         with:
           context: .
           push: true
           platforms: ${{ matrix.platform }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=platform-${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=platform-${{ matrix.platform }}


### PR DESCRIPTION
push by digestだとタグを付けてはいけないらしい