### PR TITLE
TRAQ_BOT_TOKENをTRAQ_BOT_ACCESS_TOKENに変更

### DIFF
--- a/dev/create_bot.go
+++ b/dev/create_bot.go
@@ -16,5 +16,5 @@ func main() {
 		log.Fatalf("Failed to create bot: %v", err)
 	}
 
-	fmt.Println("TRAQ_BOT_TOKEN=" + accessToken)
+	fmt.Println("TRAQ_BOT_ACCESS_TOKEN=" + accessToken)
 }

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func main() {
 	repo := gormrepository.NewGormRepository(db)
 
 	traqBaseURL := os.Getenv("TRAQ_API_BASE_URL")
-	botAccessToken := os.Getenv("TRAQ_BOT_TOKEN")
+	botAccessToken := os.Getenv("TRAQ_BOT_ACCESS_TOKEN")
 	traqService := service.NewTraqService(traqBaseURL, botAccessToken)
 
 	api.RegisterHandlers(e, router.NewServer(repo, traqService, isDev))


### PR DESCRIPTION
verification tokenと区別しやすくするため（今はverification tokenは使ってないけど）