### PR TITLE
ユニットテストごとにGORMのログが分離されるように

### DIFF
--- a/repository/gormrepository/repository_test.go
+++ b/repository/gormrepository/repository_test.go
@@ -19,6 +19,15 @@ import (
 	"github.com/traPtitech/rucQ/testutil/random"
 )
 
+type testLogWriter struct {
+	t *testing.T
+}
+
+// Printf implements the logger.Writer interface.
+func (w *testLogWriter) Printf(format string, args ...any) {
+	w.t.Logf(format, args...)
+}
+
 func setup(t *testing.T) *Repository {
 	t.Helper()
 
@@ -76,7 +85,10 @@ func setup(t *testing.T) *Repository {
 	config.Loc = loc
 
 	db, err := gorm.Open(gormMysql.Open(config.FormatDSN()), &gorm.Config{
-		Logger:         logger.Default.LogMode(logger.Info),
+		Logger: logger.New(
+			&testLogWriter{t: t},
+			logger.Config{Colorful: true, LogLevel: logger.Info},
+		),
 		TranslateError: true,
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
Closes #172
コンテナ作成・削除などのログも良い感じに分離したかったが、コントロールできなさそうだったので諦めた