### PR TITLE
`created_at`がゼロ値で上書きされないように修正

### DIFF
--- a/migration/migrate.go
+++ b/migration/migrate.go
@@ -20,5 +20,6 @@ func Migrate(db *gorm.DB) error {
 func getAllMigrations() []*gormigrate.Migration {
 	return []*gormigrate.Migration{
 		v1(), // questionsテーブルにis_requiredカラムを追加
+		v2(), // ゼロ値で上書きされてしまっていたcreated_atを修正
 	}
 }

--- a/migration/v2.go
+++ b/migration/v2.go
@@ -1,0 +1,49 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+type v2Camp struct {
+	gorm.Model
+}
+
+func (v2Camp) TableName() string {
+	return "camps"
+}
+
+type v2Question struct {
+	gorm.Model
+}
+
+func (v2Question) TableName() string {
+	return "questions"
+}
+
+func v2() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "2",
+		Migrate: func(db *gorm.DB) error {
+			ctx := context.Background()
+
+			if _, err := gorm.G[v2Camp](db).
+				Where("created_at = ?", time.Time{}).
+				Update(ctx, "created_at", gorm.Expr("updated_at")); err != nil {
+				return fmt.Errorf("failed to update created_at in camps: %w", err)
+			}
+
+			if _, err := gorm.G[v2Question](db).
+				Where("created_at = ?", time.Time{}).
+				Update(ctx, "created_at", gorm.Expr("updated_at")); err != nil {
+				return fmt.Errorf("failed to update created_at in questions: %w", err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/repository/gormrepository/camp.go
+++ b/repository/gormrepository/camp.go
@@ -52,7 +52,16 @@ func (r *Repository) GetCampByID(ctx context.Context, id uint) (*model.Camp, err
 func (r *Repository) UpdateCamp(ctx context.Context, campID uint, camp *model.Camp) error {
 	rowsAffected, err := gorm.G[*model.Camp](r.db).
 		Where("id = ?", campID).
-		Select("*").
+		Select(
+			"display_id",
+			"name",
+			"guidebook",
+			"is_draft",
+			"is_payment_open",
+			"is_registration_open",
+			"date_start",
+			"date_end",
+		).
 		Updates(ctx, camp)
 
 	if err != nil {

--- a/repository/gormrepository/camp_test.go
+++ b/repository/gormrepository/camp_test.go
@@ -144,40 +144,12 @@ func TestUpdateCamp(t *testing.T) {
 		assert.WithinDuration(t, newDateEnd, retrievedCamp.DateEnd, time.Second)
 	})
 
-	t.Run("部分更新", func(t *testing.T) {
-		t.Parallel()
-
-		r := setup(t)
-		camp := mustCreateCamp(t, r)
-
-		// 名前だけを更新するためのマップを使用
-		// Select("*")を使用しているため、構造体の場合はゼロ値も更新される
-		err := r.db.Model(&model.Camp{}).
-			Where("id = ?", camp.ID).
-			Update("name", random.AlphaNumericString(t, 25)).Error
-		require.NoError(t, err)
-
-		// 更新後のデータを取得して確認
-		retrievedCamp, err := r.GetCampByID(t.Context(), camp.ID)
-		require.NoError(t, err)
-
-		// 他のフィールドは元のまま
-		assert.Equal(t, camp.DisplayID, retrievedCamp.DisplayID)
-		assert.Equal(t, camp.Guidebook, retrievedCamp.Guidebook)
-		assert.Equal(t, camp.IsDraft, retrievedCamp.IsDraft)
-		assert.Equal(t, camp.IsPaymentOpen, retrievedCamp.IsPaymentOpen)
-		assert.Equal(t, camp.IsRegistrationOpen, retrievedCamp.IsRegistrationOpen)
-		assert.WithinDuration(t, camp.DateStart, retrievedCamp.DateStart, time.Second)
-		assert.WithinDuration(t, camp.DateEnd, retrievedCamp.DateEnd, time.Second)
-	})
-
 	t.Run("ゼロ値での更新", func(t *testing.T) {
 		t.Parallel()
 
 		r := setup(t)
 		camp := mustCreateCamp(t, r)
 
-		// Select("*")を使用しているため、ゼロ値でも更新される
 		zeroValueUpdate := model.Camp{
 			Name:               "", // 空文字列
 			Guidebook:          "", // 空文字列
@@ -191,7 +163,7 @@ func TestUpdateCamp(t *testing.T) {
 
 		// 更新後のデータを取得して確認
 		retrievedCamp, err := r.GetCampByID(t.Context(), camp.ID)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		// ゼロ値が設定されていることを確認
 		assert.Equal(t, "", retrievedCamp.Name)

--- a/repository/gormrepository/camp_test.go
+++ b/repository/gormrepository/camp_test.go
@@ -142,6 +142,8 @@ func TestUpdateCamp(t *testing.T) {
 		// 時刻の比較は秒単位で行う（MySQLの時刻精度の問題を回避）
 		assert.WithinDuration(t, newDateStart, retrievedCamp.DateStart, time.Second)
 		assert.WithinDuration(t, newDateEnd, retrievedCamp.DateEnd, time.Second)
+		// CreatedAtが変わっていないことを確認
+		assert.WithinDuration(t, camp.CreatedAt, retrievedCamp.CreatedAt, time.Second)
 	})
 
 	t.Run("ゼロ値での更新", func(t *testing.T) {
@@ -171,6 +173,8 @@ func TestUpdateCamp(t *testing.T) {
 		assert.False(t, retrievedCamp.IsDraft)
 		assert.False(t, retrievedCamp.IsPaymentOpen)
 		assert.False(t, retrievedCamp.IsRegistrationOpen)
+		// CreatedAtが変わっていないことを確認
+		assert.WithinDuration(t, camp.CreatedAt, retrievedCamp.CreatedAt, time.Second)
 	})
 
 	t.Run("存在しない合宿での更新はエラーになる", func(t *testing.T) {

--- a/repository/gormrepository/question.go
+++ b/repository/gormrepository/question.go
@@ -53,8 +53,15 @@ func (r *Repository) UpdateQuestion(
 
 	if err := r.db.WithContext(ctx).
 		Session(&gorm.Session{FullSaveAssociations: true}).
-		Select("*").
-		Omit("question_group_id").
+		Select(
+			"type",
+			"title",
+			"description",
+			"is_public",
+			"is_open",
+			"is_required",
+			"Options",
+		).
 		Updates(question).Error; err != nil {
 		return err
 	}

--- a/repository/gormrepository/question_test.go
+++ b/repository/gormrepository/question_test.go
@@ -2,6 +2,7 @@ package gormrepository
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -118,5 +119,8 @@ func TestUpdateQuestion(t *testing.T) {
 			assert.Equal(t, updatedOption.ID, retrievedQuestion.Options[i].ID)
 			assert.Equal(t, updatedOption.Content, retrievedQuestion.Options[i].Content)
 		}
+
+		// CreatedAtが変わっていないことを確認
+		assert.WithinDuration(t, question.CreatedAt, retrievedQuestion.CreatedAt, time.Second)
 	})
 }


### PR DESCRIPTION
Closes #168
既に上書きされてしまった部分は正確に復元することができないため、`updated_at`で更新する　ゼロ値よりはマシ