### PR TITLE
fix(router): return 404 when payment camp does not exist

### DIFF
--- a/router/payments.go
+++ b/router/payments.go
@@ -64,6 +64,15 @@ func (s *Server) AdminPostPayment(
 		return echo.NewHTTPError(http.StatusForbidden, "Forbidden")
 	}
 
+	if _, err := s.repo.GetCampByID(e.Request().Context(), uint(campID)); err != nil {
+		if errors.Is(err, repository.ErrCampNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Camp not found")
+		}
+
+		return echo.NewHTTPError(http.StatusInternalServerError).
+			SetInternal(fmt.Errorf("failed to get camp: %w", err))
+	}
+
 	var req api.AdminPostPaymentJSONRequestBody
 
 	if err := e.Bind(&req); err != nil {

--- a/router/payments_test.go
+++ b/router/payments_test.go
@@ -34,6 +34,9 @@ func TestAdminPostPayment(t *testing.T) {
 			Return(&model.User{
 				IsStaff: true,
 			}, nil)
+		h.repo.MockCampRepository.EXPECT().
+			GetCampByID(gomock.Any(), uint(campID)).
+			Return(&model.Camp{}, nil)
 		h.repo.MockPaymentRepository.EXPECT().CreatePayment(gomock.Any(), gomock.Any()).Return(nil)
 		h.activityService.EXPECT().
 			RecordPaymentCreated(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -70,6 +73,9 @@ func TestAdminPostPayment(t *testing.T) {
 			Return(&model.User{
 				IsStaff: true,
 			}, nil)
+		h.repo.MockCampRepository.EXPECT().
+			GetCampByID(gomock.Any(), uint(campID)).
+			Return(&model.Camp{}, nil)
 		h.repo.MockPaymentRepository.EXPECT().CreatePayment(gomock.Any(), gomock.Any()).Return(nil)
 		h.activityService.EXPECT().
 			RecordPaymentCreated(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -80,6 +86,33 @@ func TestAdminPostPayment(t *testing.T) {
 			WithJSON(req).
 			WithHeader("X-Forwarded-User", adminUserID).
 			Expect().Status(http.StatusInternalServerError)
+	})
+
+	t.Run("Camp not found", func(t *testing.T) {
+		t.Parallel()
+
+		h := setup(t)
+		campID := random.PositiveInt(t)
+		req := api.AdminPostPaymentJSONRequestBody{
+			Amount:     random.PositiveInt(t),
+			AmountPaid: random.PositiveInt(t),
+			UserId:     random.AlphaNumericString(t, 32),
+		}
+		adminUserID := random.AlphaNumericString(t, 32)
+
+		h.repo.MockUserRepository.EXPECT().
+			GetOrCreateUser(gomock.Any(), adminUserID).
+			Return(&model.User{
+				IsStaff: true,
+			}, nil)
+		h.repo.MockCampRepository.EXPECT().
+			GetCampByID(gomock.Any(), uint(campID)).
+			Return(nil, repository.ErrCampNotFound)
+
+		h.expect.POST("/api/admin/camps/{campId}/payments", campID).
+			WithJSON(req).
+			WithHeader("X-Forwarded-User", adminUserID).
+			Expect().Status(http.StatusNotFound)
 	})
 }
 


### PR DESCRIPTION
close #317

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* 支払い作成時にキャンプの存在が事前確認されるようになりました。キャンプが見つからない場合は、適切なエラーレスポンスが返されます
* エラーハンドリングが改善され、より詳細なステータスコードが返されるようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->