### PR TITLE
Renovateのアップデート後に`go mod tidy`を実行

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,5 +20,8 @@
         "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\n\\s*version:\\s*(?<currentValue>[^\\s]+)"
       ]
     }
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
   ]
 }


### PR DESCRIPTION
closes #349

Renovateはデフォルトでは`go mod tidy`を実行してくれず、go.modやgo.sumから古いバージョンの情報が消えないので自動で実行させるようにしました

参考：https://docs.renovatebot.com/configuration-options/#postupdateoptions
関連：#348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 依存関係の自動管理設定を強化しました。アップデート処理実行時に追加の整理処理を自動実行するよう設定を更新し、プロジェクトの Go モジュール依存関係がより効率的かつ整合的に管理されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->