### PR TITLE
fix: 部屋のステータスが変更されていないときログを残さない #320

### DIFF
--- a/repository/gormrepository/room_status.go
+++ b/repository/gormrepository/room_status.go
@@ -19,6 +19,18 @@ func (r *Repository) SetRoomStatus(
 	operatorID string,
 ) error {
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		currentStatus, err := gorm.G[model.RoomStatus](tx).
+			Where("room_id = ?", roomID).
+			Take(ctx)
+
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+
+		if err == nil && roomStatusContentEquals(currentStatus, status) {
+			return nil
+		}
+
 		newStatus := status
 		newStatus.RoomID = roomID
 		newStatus.UpdatedAt = time.Now()
@@ -62,6 +74,18 @@ func (r *Repository) SetRoomStatus(
 
 		return nil
 	})
+}
+
+func roomStatusContentEquals(a, b model.RoomStatus) bool {
+	if a.Topic != b.Topic {
+		return false
+	}
+
+	if a.Type == nil || b.Type == nil {
+		return a.Type == nil && b.Type == nil
+	}
+
+	return *a.Type == *b.Type
 }
 
 func (r *Repository) GetRoomStatusLogs(

--- a/repository/gormrepository/room_status_test.go
+++ b/repository/gormrepository/room_status_test.go
@@ -127,6 +127,33 @@ func TestRepository_SetRoomStatus(t *testing.T) {
 		}
 	})
 
+	t.Run("同じ内容で更新しても履歴は増えない", func(t *testing.T) {
+		t.Parallel()
+
+		r := setup(t)
+		camp := mustCreateCamp(t, r)
+		roomGroup := mustCreateRoomGroup(t, r, camp.ID)
+		room := mustCreateRoom(t, r, roomGroup.ID, []model.User{})
+
+		operator := mustCreateUser(t, r)
+		operatorID := operator.ID
+		topic := random.AlphaNumericString(t, roomStatusTopicMaxLength)
+		statusType := random.SelectFrom(t, "active", "inactive")
+		status := model.RoomStatus{
+			Type:  &statusType,
+			Topic: topic,
+		}
+
+		mustSetRoomStatus(t, r, room.ID, status, operatorID)
+
+		err := r.SetRoomStatus(t.Context(), room.ID, status, operatorID)
+		assert.NoError(t, err)
+
+		logs, err := r.GetRoomStatusLogs(t.Context(), room.ID)
+		assert.NoError(t, err)
+		assert.Len(t, logs, 1)
+	})
+
 	t.Run("マルチバイト文字でも64文字までは保存できる", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
close #320 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 同じ内容でのステータス更新時に不要なログ作成を防止

* **テスト**
  * べき等性更新の動作確認テストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->