### PR TITLE
参加登録解除済みの人が部屋のメンバーに含まれているの修正

### DIFF
--- a/repository/gormrepository/room_group.go
+++ b/repository/gormrepository/room_group.go
@@ -98,7 +98,16 @@ func (r *Repository) GetRoomGroupByID(
 
 func (r *Repository) GetRoomGroups(ctx context.Context, campID uint) ([]model.RoomGroup, error) {
 	roomGroups, err := gorm.G[model.RoomGroup](r.db).
-		Preload("Rooms.Members", nil).
+		Preload("Rooms.Members", func(db gorm.PreloadBuilder) error {
+			subQuery := r.db.Table("camp_participants").
+				Select("1").
+				Where("camp_participants.camp_id = ?", campID).
+				Where("camp_participants.user_id = users.id")
+
+			db.Where("EXISTS (?)", subQuery)
+
+			return nil
+		}).
 		Preload("Rooms.Status", nil).
 		Where("camp_id = ?", campID).
 		Find(ctx)

--- a/repository/gormrepository/room_group_test.go
+++ b/repository/gormrepository/room_group_test.go
@@ -386,6 +386,36 @@ func TestRepository_GetRoomGroups(t *testing.T) {
 		}
 	})
 
+	t.Run("Deregistered users are not included in room members", func(t *testing.T) {
+		t.Parallel()
+
+		r := setup(t)
+		camp := mustCreateCamp(t, r)
+		roomGroup := mustCreateRoomGroup(t, r, camp.ID)
+		activeUser := mustCreateUser(t, r)
+		removedUser := mustCreateUser(t, r)
+
+		require.NoError(t, r.AddCampParticipant(t.Context(), camp.ID, &activeUser))
+		require.NoError(t, r.AddCampParticipant(t.Context(), camp.ID, &removedUser))
+		require.NoError(t, r.RemoveCampParticipant(t.Context(), camp.ID, &removedUser))
+
+		room := &model.Room{
+			Name:        random.AlphaNumericString(t, 10),
+			RoomGroupID: roomGroup.ID,
+			Members:     []model.User{activeUser, removedUser},
+		}
+		require.NoError(t, r.CreateRoom(t.Context(), room))
+
+		roomGroups, err := r.GetRoomGroups(t.Context(), camp.ID)
+
+		assert.NoError(t, err)
+		if assert.Len(t, roomGroups, 1) &&
+			assert.Len(t, roomGroups[0].Rooms, 1) &&
+			assert.Len(t, roomGroups[0].Rooms[0].Members, 1) {
+			assert.Equal(t, activeUser.ID, roomGroups[0].Rooms[0].Members[0].ID)
+		}
+	})
+
 	t.Run("最新のステータスが含まれる", func(t *testing.T) {
 		t.Parallel()
 

--- a/repository/gormrepository/room_group_test.go
+++ b/repository/gormrepository/room_group_test.go
@@ -328,6 +328,8 @@ func TestRepository_GetRoomGroups(t *testing.T) {
 		_ = mustCreateRoomGroup(t, r, camp2.ID)
 		user1 := mustCreateUser(t, r)
 		user2 := mustCreateUser(t, r)
+		require.NoError(t, r.AddCampParticipant(t.Context(), camp1.ID, &user1))
+		require.NoError(t, r.AddCampParticipant(t.Context(), camp1.ID, &user2))
 		// room group1に部屋を作成
 		room1 := &model.Room{
 			Name:        random.AlphaNumericString(t, 10),


### PR DESCRIPTION
Closes #321
# 実装の概要
この問題の原因はあるユーザーが登録を解除したとき、RemoveCampParticipant()が走り、データベース側では、camp_participantsが変更されていますが、部屋グループを取得するとき(GetRoomGroups()が呼ばれるとき)、 room_membersを参照していたので、room_membersには削除の変更が走っていないことでした。
これを解決するために、room_membersのうち、camp_participantsにも載っているユーザーのみ返すように書き換えました。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ルームグループ取得時に、キャンプ参加者に紐づくメンバーだけを表示するようになりました。
  * 退会・非参加のユーザーがルームメンバー一覧に残らないよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->