### PR TITLE
fix/QuestionGroupsで存在しないcampIDだったら404を返す

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -461,6 +461,8 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/QuestionGroupResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -490,7 +490,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/QuestionGroupResponse"
         "400":
-          $ref: "#/components/responses/BadRequest"
+          $ref: "#/components/responses/NotFound"
         "403":
           $ref: "#/components/responses/Forbidden"
         "500":

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -490,9 +490,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/QuestionGroupResponse"
         "400":
-          $ref: "#/components/responses/NotFound"
+          $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
   /api/admin/question-groups/{questionGroupId}:

--- a/repository/gormrepository/question_group.go
+++ b/repository/gormrepository/question_group.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/traPtitech/rucQ/model"
+	"github.com/traPtitech/rucQ/repository"
 )
 
 func (r *Repository) CreateQuestionGroup(questionGroup *model.QuestionGroup) error {
@@ -28,6 +29,19 @@ func (r *Repository) GetQuestionGroups(
 
 	if err != nil {
 		return nil, err
+	}
+
+	// questionGroupsが見つからなかった場合、Campが存在しない可能性を考慮してCampの存在確認を行う
+	if len(questionGroups) == 0 {
+		campExists, err := r.campExists(ctx, campID)
+
+		if err != nil {
+			return nil, err
+		}
+
+		if !campExists {
+			return nil, repository.ErrCampNotFound
+		}
 	}
 
 	return questionGroups, nil

--- a/repository/gormrepository/question_group.go
+++ b/repository/gormrepository/question_group.go
@@ -12,6 +12,9 @@ import (
 
 func (r *Repository) CreateQuestionGroup(questionGroup *model.QuestionGroup) error {
 	if err := r.db.Create(questionGroup).Error; err != nil {
+		if errors.Is(err, gorm.ErrForeignKeyViolated) {
+			return repository.ErrCampNotFound
+		}
 		return err
 	}
 

--- a/repository/gormrepository/question_group_test.go
+++ b/repository/gormrepository/question_group_test.go
@@ -222,10 +222,10 @@ func TestGetQuestionGroup(t *testing.T) {
 		r := setup(t)
 		nonExistentCampID := uint(random.PositiveInt(t))
 
-		roomGroups, err := r.GetRoomGroups(t.Context(), nonExistentCampID)
+		questionGroups, err := r.GetQuestionGroups(t.Context(), nonExistentCampID)
 
 		assert.ErrorIs(t, err, repository.ErrCampNotFound)
-		assert.Nil(t, roomGroups)
+		assert.Nil(t, questionGroups)
 	})
 }
 

--- a/repository/gormrepository/question_group_test.go
+++ b/repository/gormrepository/question_group_test.go
@@ -177,71 +177,15 @@ func TestCreateQuestionGroup(t *testing.T) {
 		t.Parallel()
 
 		r := setup(t)
-		name := random.AlphaNumericString(t, 20)
-		description := random.PtrOrNil(t, random.AlphaNumericString(t, 100))
-		due := random.Time(t)
-		questions := []model.Question{
-			{
-				Type:        model.FreeTextQuestion,
-				Title:       random.AlphaNumericString(t, 20),
-				Description: random.PtrOrNil(t, random.AlphaNumericString(t, 100)),
-				IsPublic:    random.Bool(t),
-				IsOpen:      random.Bool(t),
-				IsRequired:  random.Bool(t),
-			},
-			{
-				Type:        model.FreeNumberQuestion,
-				Title:       random.AlphaNumericString(t, 20),
-				Description: random.PtrOrNil(t, random.AlphaNumericString(t, 100)),
-				IsPublic:    random.Bool(t),
-				IsOpen:      random.Bool(t),
-				IsRequired:  random.Bool(t),
-			},
-			{
-				Type:        model.SingleChoiceQuestion,
-				Title:       random.AlphaNumericString(t, 20),
-				Description: random.PtrOrNil(t, random.AlphaNumericString(t, 100)),
-				IsPublic:    random.Bool(t),
-				IsOpen:      random.Bool(t),
-				IsRequired:  random.Bool(t),
-				Options: []model.Option{
-					{
-						Content: random.AlphaNumericString(t, 20),
-					},
-				},
-			},
-			{
-				Type:        model.MultipleChoiceQuestion,
-				Title:       random.AlphaNumericString(t, 20),
-				Description: random.PtrOrNil(t, random.AlphaNumericString(t, 100)),
-				IsPublic:    random.Bool(t),
-				IsOpen:      random.Bool(t),
-				IsRequired:  random.Bool(t),
-				Options: []model.Option{
-					{
-						Content: random.AlphaNumericString(t, 20),
-					},
-					{
-						Content: random.AlphaNumericString(t, 20),
-					},
-				},
-			},
-		}
-		camp := mustCreateCamp(t, r)
 		questionGroup := model.QuestionGroup{
-			Name:        name,
-			Description: description,
-			Due:         due,
-			Questions:   questions,
-			CampID:      camp.ID,
+			Name:   random.AlphaNumericString(t, 20),
+			Due:    random.Time(t),
+			CampID: uint(random.PositiveInt(t)),
 		}
-		
 
 		err := r.CreateQuestionGroup(&questionGroup)
 
-		if assert.Error(t, err) {
-			assert.ErrorIs(t, err, model.ErrNotFound)
-		}
+		assert.ErrorIs(t, err, repository.ErrCampNotFound)
 	})
 }
 

--- a/repository/gormrepository/question_group_test.go
+++ b/repository/gormrepository/question_group_test.go
@@ -177,13 +177,70 @@ func TestCreateQuestionGroup(t *testing.T) {
 		t.Parallel()
 
 		r := setup(t)
-		nonExistentID := uint(random.PositiveInt(t))
+		name := random.AlphaNumericString(t, 20)
+		description := random.PtrOrNil(t, random.AlphaNumericString(t, 100))
+		due := random.Time(t)
+		questions := []model.Question{
+			{
+				Type:        model.FreeTextQuestion,
+				Title:       random.AlphaNumericString(t, 20),
+				Description: random.PtrOrNil(t, random.AlphaNumericString(t, 100)),
+				IsPublic:    random.Bool(t),
+				IsOpen:      random.Bool(t),
+				IsRequired:  random.Bool(t),
+			},
+			{
+				Type:        model.FreeNumberQuestion,
+				Title:       random.AlphaNumericString(t, 20),
+				Description: random.PtrOrNil(t, random.AlphaNumericString(t, 100)),
+				IsPublic:    random.Bool(t),
+				IsOpen:      random.Bool(t),
+				IsRequired:  random.Bool(t),
+			},
+			{
+				Type:        model.SingleChoiceQuestion,
+				Title:       random.AlphaNumericString(t, 20),
+				Description: random.PtrOrNil(t, random.AlphaNumericString(t, 100)),
+				IsPublic:    random.Bool(t),
+				IsOpen:      random.Bool(t),
+				IsRequired:  random.Bool(t),
+				Options: []model.Option{
+					{
+						Content: random.AlphaNumericString(t, 20),
+					},
+				},
+			},
+			{
+				Type:        model.MultipleChoiceQuestion,
+				Title:       random.AlphaNumericString(t, 20),
+				Description: random.PtrOrNil(t, random.AlphaNumericString(t, 100)),
+				IsPublic:    random.Bool(t),
+				IsOpen:      random.Bool(t),
+				IsRequired:  random.Bool(t),
+				Options: []model.Option{
+					{
+						Content: random.AlphaNumericString(t, 20),
+					},
+					{
+						Content: random.AlphaNumericString(t, 20),
+					},
+				},
+			},
+		}
+		camp := mustCreateCamp(t, r)
+		questionGroup := model.QuestionGroup{
+			Name:        name,
+			Description: description,
+			Due:         due,
+			Questions:   questions,
+			CampID:      camp.ID,
+		}
+		
 
-		result, err := r.GetQuestionGroup(t.Context(), nonExistentID)
+		err := r.CreateQuestionGroup(&questionGroup)
 
 		if assert.Error(t, err) {
 			assert.ErrorIs(t, err, model.ErrNotFound)
-			assert.Nil(t, result)
 		}
 	})
 }

--- a/repository/gormrepository/question_group_test.go
+++ b/repository/gormrepository/question_group_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/traPtitech/rucQ/model"
+	"github.com/traPtitech/rucQ/repository"
 	"github.com/traPtitech/rucQ/testutil/random"
 )
 
@@ -213,6 +214,18 @@ func TestGetQuestionGroup(t *testing.T) {
 			assert.ErrorIs(t, err, model.ErrNotFound)
 			assert.Nil(t, result)
 		}
+	})
+
+	t.Run("Non-existent Camp", func(t *testing.T) {
+		t.Parallel()
+
+		r := setup(t)
+		nonExistentCampID := uint(random.PositiveInt(t))
+
+		roomGroups, err := r.GetRoomGroups(t.Context(), nonExistentCampID)
+
+		assert.ErrorIs(t, err, repository.ErrCampNotFound)
+		assert.Nil(t, roomGroups)
 	})
 }
 

--- a/repository/gormrepository/question_group_test.go
+++ b/repository/gormrepository/question_group_test.go
@@ -55,6 +55,17 @@ func TestGetQuestionGroups(t *testing.T) {
 		assert.Equal(t, camp.ID, questionGroups[1].CampID)
 		assert.Len(t, questionGroups[1].Questions, 0)
 	})
+	t.Run("Non-existent Camp", func(t *testing.T) {
+		t.Parallel()
+
+		r := setup(t)
+		nonExistentCampID := uint(random.PositiveInt(t))
+
+		questionGroups, err := r.GetQuestionGroups(t.Context(), nonExistentCampID)
+
+		assert.ErrorIs(t, err, repository.ErrCampNotFound)
+		assert.Nil(t, questionGroups)
+	})
 }
 
 func TestCreateQuestionGroup(t *testing.T) {
@@ -162,6 +173,19 @@ func TestCreateQuestionGroup(t *testing.T) {
 			}
 		}
 	})
+	t.Run("NotFound", func(t *testing.T) {
+		t.Parallel()
+
+		r := setup(t)
+		nonExistentID := uint(random.PositiveInt(t))
+
+		result, err := r.GetQuestionGroup(t.Context(), nonExistentID)
+
+		if assert.Error(t, err) {
+			assert.ErrorIs(t, err, model.ErrNotFound)
+			assert.Nil(t, result)
+		}
+	})
 }
 
 func TestGetQuestionGroup(t *testing.T) {
@@ -214,18 +238,6 @@ func TestGetQuestionGroup(t *testing.T) {
 			assert.ErrorIs(t, err, model.ErrNotFound)
 			assert.Nil(t, result)
 		}
-	})
-
-	t.Run("Non-existent Camp", func(t *testing.T) {
-		t.Parallel()
-
-		r := setup(t)
-		nonExistentCampID := uint(random.PositiveInt(t))
-
-		questionGroups, err := r.GetQuestionGroups(t.Context(), nonExistentCampID)
-
-		assert.ErrorIs(t, err, repository.ErrCampNotFound)
-		assert.Nil(t, questionGroups)
 	})
 }
 

--- a/router/question_groups.go
+++ b/router/question_groups.go
@@ -42,9 +42,6 @@ func (s *Server) AdminPostQuestionGroup(
 	user, err := s.repo.GetOrCreateUser(e.Request().Context(), *params.XForwardedUser)
 
 	if err != nil {
-		if errors.Is(err, repository.ErrCampNotFound) {
-			return echo.NewHTTPError(http.StatusNotFound, "Camp not found")
-		}
 		return echo.NewHTTPError(http.StatusInternalServerError).
 			SetInternal(fmt.Errorf("failed to get or create user: %w", err))
 	}

--- a/router/question_groups.go
+++ b/router/question_groups.go
@@ -77,6 +77,9 @@ func (s *Server) AdminPostQuestionGroup(
 
 		return s.activityService.RecordQuestionCreated(ctx, tx, questionGroup)
 	}); err != nil {
+		if errors.Is(err, repository.ErrCampNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Camp not found")
+		}
 		return echo.NewHTTPError(http.StatusInternalServerError).
 			SetInternal(err)
 	}

--- a/router/question_groups.go
+++ b/router/question_groups.go
@@ -42,6 +42,9 @@ func (s *Server) AdminPostQuestionGroup(
 	user, err := s.repo.GetOrCreateUser(e.Request().Context(), *params.XForwardedUser)
 
 	if err != nil {
+		if errors.Is(err, repository.ErrCampNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Camp not found")
+		}
 		return echo.NewHTTPError(http.StatusInternalServerError).
 			SetInternal(fmt.Errorf("failed to get or create user: %w", err))
 	}

--- a/router/question_groups.go
+++ b/router/question_groups.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -16,6 +17,9 @@ func (s *Server) GetQuestionGroups(e echo.Context, campID api.CampId) error {
 	questionGroups, err := s.repo.GetQuestionGroups(e.Request().Context(), uint(campID))
 
 	if err != nil {
+		if errors.Is(err, repository.ErrCampNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Camp not found")
+		}
 		return echo.NewHTTPError(http.StatusInternalServerError).
 			SetInternal(fmt.Errorf("failed to get question groups: %w", err))
 	}

--- a/router/question_groups_test.go
+++ b/router/question_groups_test.go
@@ -398,7 +398,7 @@ func TestAdminPostQuestionGroup(t *testing.T) {
 			GetQuestionGroups(gomock.Any(), uint(campID)).
 			Return(nil, repository.ErrCampNotFound)
 
-		h.expect.POST("/api/camps/{campId}/question-groups", campID).
+		h.expect.POST("/api/admin/camps/{campId}/question-groups", campID).
 			Expect().
 			Status(http.StatusNotFound).JSON().Object().
 			Value("message").String().IsEqual("Camp not found")

--- a/router/question_groups_test.go
+++ b/router/question_groups_test.go
@@ -145,11 +145,11 @@ func TestGetQuestionGroups(t *testing.T) {
 
 		campID := random.PositiveInt(t)
 
-		h.repo.MockRoomGroupRepository.EXPECT().
-			GetRoomGroups(gomock.Any(), uint(campID)).
+		h.repo.MockQuestionGroupRepository.EXPECT().
+			GetQuestionGroups(gomock.Any(), uint(campID)).
 			Return(nil, repository.ErrCampNotFound)
 
-		h.expect.GET("/api/camps/{campId}/room-groups", campID).
+		h.expect.GET("/api/camps/{campId}/question-groups", campID).
 			Expect().
 			Status(http.StatusNotFound).JSON().Object().
 			Value("message").String().IsEqual("Camp not found")

--- a/router/question_groups_test.go
+++ b/router/question_groups_test.go
@@ -387,6 +387,23 @@ func TestAdminPostQuestionGroup(t *testing.T) {
 			IsEqual(multipleChoiceQuestion.Options[2].Content)
 	})
 
+	t.Run("Camp Not Found", func(t *testing.T) {
+		t.Parallel()
+
+		h := setup(t)
+
+		campID := random.PositiveInt(t)
+
+		h.repo.MockQuestionGroupRepository.EXPECT().
+			GetQuestionGroups(gomock.Any(), uint(campID)).
+			Return(nil, repository.ErrCampNotFound)
+
+		h.expect.GET("/api/camps/{campId}/question-groups", campID).
+			Expect().
+			Status(http.StatusNotFound).JSON().Object().
+			Value("message").String().IsEqual("Camp not found")
+	})
+
 	t.Run("Activity service error", func(t *testing.T) {
 		t.Parallel()
 

--- a/router/question_groups_test.go
+++ b/router/question_groups_test.go
@@ -392,21 +392,20 @@ func TestAdminPostQuestionGroup(t *testing.T) {
 
 		h := setup(t)
 
-		req := api.AdminPostRoomGroupJSONRequestBody{
+		req := api.AdminPostQuestionGroupJSONRequestBody{
 			Name: random.AlphaNumericString(t, 20),
 		}
 		username := random.AlphaNumericString(t, 32)
 		campID := random.PositiveInt(t)
-		userID := random.AlphaNumericString(t, 32)
 
 		h.repo.MockUserRepository.EXPECT().
-			GetOrCreateUser(gomock.Any(), userID).
+			GetOrCreateUser(gomock.Any(), username).
 			Return(&model.User{IsStaff: true}, nil).
 			Times(1)
-			
+
 		h.repo.MockQuestionGroupRepository.EXPECT().
 			CreateQuestionGroup(gomock.Any()).
-			Return(nil, repository.ErrCampNotFound)
+			Return(repository.ErrCampNotFound)
 
 		h.expect.POST("/api/admin/camps/{campId}/question-groups", campID).
 			WithJSON(req).

--- a/router/question_groups_test.go
+++ b/router/question_groups_test.go
@@ -398,7 +398,7 @@ func TestAdminPostQuestionGroup(t *testing.T) {
 			GetQuestionGroups(gomock.Any(), uint(campID)).
 			Return(nil, repository.ErrCampNotFound)
 
-		h.expect.GET("/api/camps/{campId}/question-groups", campID).
+		h.expect.POST("/api/camps/{campId}/question-groups", campID).
 			Expect().
 			Status(http.StatusNotFound).JSON().Object().
 			Value("message").String().IsEqual("Camp not found")

--- a/router/question_groups_test.go
+++ b/router/question_groups_test.go
@@ -392,13 +392,25 @@ func TestAdminPostQuestionGroup(t *testing.T) {
 
 		h := setup(t)
 
+		req := api.AdminPostRoomGroupJSONRequestBody{
+			Name: random.AlphaNumericString(t, 20),
+		}
+		username := random.AlphaNumericString(t, 32)
 		campID := random.PositiveInt(t)
+		userID := random.AlphaNumericString(t, 32)
 
+		h.repo.MockUserRepository.EXPECT().
+			GetOrCreateUser(gomock.Any(), userID).
+			Return(&model.User{IsStaff: true}, nil).
+			Times(1)
+			
 		h.repo.MockQuestionGroupRepository.EXPECT().
-			GetQuestionGroups(gomock.Any(), uint(campID)).
+			CreateQuestionGroup(gomock.Any()).
 			Return(nil, repository.ErrCampNotFound)
 
 		h.expect.POST("/api/admin/camps/{campId}/question-groups", campID).
+			WithJSON(req).
+			WithHeader("X-Forwarded-User", username).
 			Expect().
 			Status(http.StatusNotFound).JSON().Object().
 			Value("message").String().IsEqual("Camp not found")

--- a/router/question_groups_test.go
+++ b/router/question_groups_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/traPtitech/rucQ/api"
 	"github.com/traPtitech/rucQ/model"
+	"github.com/traPtitech/rucQ/repository"
 	"github.com/traPtitech/rucQ/testutil/random"
 )
 
@@ -135,6 +136,23 @@ func TestGetQuestionGroups(t *testing.T) {
 		}
 
 		res2.Value("due").String().IsEqual(questionGroup2.Due.Format(time.DateOnly))
+	})
+
+	t.Run("Camp Not Found", func(t *testing.T) {
+		t.Parallel()
+
+		h := setup(t)
+
+		campID := random.PositiveInt(t)
+
+		h.repo.MockRoomGroupRepository.EXPECT().
+			GetRoomGroups(gomock.Any(), uint(campID)).
+			Return(nil, repository.ErrCampNotFound)
+
+		h.expect.GET("/api/camps/{campId}/room-groups", campID).
+			Expect().
+			Status(http.StatusNotFound).JSON().Object().
+			Value("message").String().IsEqual("Camp not found")
 	})
 }
 


### PR DESCRIPTION
close #140 
QuestionGroupsで返り値が無かった場合に、campIDの存在確認をするようにした
RouterのQuestionGroupにNot Foundを追加した
OpenAPIに404 Not Foundを追加した

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * キャンプID指定の問合せ（`GET /api/camps/{campId}/question-groups`、管理用`POST /api/admin/camps/{campId}/question-groups`）で、対象キャンプが存在しない場合は `404 Not Found`（`"Camp not found"`）を返すようになりました。結果が0件の場合は従来どおり空で返します。
  * API仕様のレスポンス定義に `404` を追加し、エラー応答を明確化しました。
* **Tests**
  * 存在しないキャンプ時の `404`、メッセージ（`"Camp not found"`）、戻り値（`nil`）を検証するケースを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->