### PR TITLE
fix: reduce context cancellation log level

### DIFF
--- a/main.go
+++ b/main.go
@@ -156,6 +156,14 @@ func main() {
 
 	go func() {
 		if err := e.StartServer(srv); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			if errors.Is(err, context.Canceled) {
+				if cause := context.Cause(ctx); cause != nil {
+					slog.Info("server stopped", slog.String("cause", cause.Error()))
+				} else {
+					slog.Info("server stopped")
+				}
+				return
+			}
 			slog.Error("server error", slog.String("error", err.Error()))
 		}
 	}()


### PR DESCRIPTION
## Summary
Reduce expected `context.Canceled` server shutdowns from error-level logging and include the cancellation cause when it is available.

## Changes
- Log `context.Canceled` results from `e.StartServer` at `INFO` level.
- Add the associated `context.Cause` as structured log data when present.
- Preserve error-level logging for unexpected server errors.

## Related issue
Fixes #364

## Validation
- `git diff --check` — passed
- Added-line static security scan — no findings
- `go test ./...` / `gofmt` could not be run because the Go toolchain is not installed in the runner.
- `docker build -t rucq-validation:local .` could not run because the local Docker daemon is unavailable.

## Notes
This is a minimal, automated-tooling-assisted contribution. Please rely on repository CI for Go formatting, compilation, and tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * サーバー停止時のキャンセルを通常のサーバーエラーとして記録しないよう改善しました。
  * 終了理由を情報ログで確認できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->