### PR TITLE
renovate: セキュリティ系のアップデートをすぐに受け取れるよう修正

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,7 +5,8 @@
     "config:recommended",
     ":disableDependencyDashboard",
     ":disableRateLimiting",
-    "schedule:monthly"
+    "schedule:monthly",
+    "security:gomodIndirectSecurityUpdates"
   ],
   "customManagers": [
     {

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -7,9 +7,8 @@ on:
       - main
 
   schedule:
-    # RenovateがPRを作成できるのは1日の午前0時から4時までなので（schedule:monthly）、
-    # 毎月1日の午前2時に実行する
-    - cron: "0 2 1 * *"
+    # セキュリティ系のアップデートを確認するため毎日実行する
+    - cron: "0 2 * * *"
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
closes #358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **セキュリティ**
  * Go Modulesの間接依存関係におけるセキュリティ更新を検出できるようになりました。
  * セキュリティ更新の確認頻度が、毎月から毎日（午前2時）に変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->